### PR TITLE
Feature/fix escape on legacy form

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.2.0 - 2024-12-17 =
+* Added - Support GiveWP 3.0 Visual Donation Form Builder.
+
 = 1.1.0 - 2023-10-27 =
 * Changed - Now the redirection will not rely on session. Instead it will rely on meta.
 * Changed - Now reference is set to donation id instead of payment_key

--- a/chip-for-givewp.php
+++ b/chip-for-givewp.php
@@ -4,16 +4,16 @@
  * Plugin Name: CHIP for GiveWP
  * Plugin URI: https://wordpress.org/plugins/chip-for-givewp/
  * Description: CHIP - Digital Finance Platform
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Chip In Sdn Bhd
  * Author URI: https://www.chip-in.asia
  *
- * Copyright: © 2024 CHIP
+ * Copyright: © 2025 CHIP
  * License: GNU General Public License v3.0
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
-define( 'GWP_CHIP_MODULE_VERSION', 'v1.2.0' );
+define( 'GWP_CHIP_MODULE_VERSION', 'v1.2.1' );
 
 class Chip_Givewp {
 

--- a/includes/admin/class-refund-button.php
+++ b/includes/admin/class-refund-button.php
@@ -64,7 +64,7 @@ class Chip_Givewp_Refund_Button {
 
 		check_admin_referer( 'gwp_chip_refund_payment', 'gwp_chip_refund_payment' );
 
-		$donation_id = absint( $_POST['donation_id'] ?? 0 );
+		$donation_id = absint( $_POST['donation_id'] ?? '' );
 
 		if ( empty( $donation_id ) ) {
 			Chip_Givewp_Helper::log( null, LogType::ERROR, __( 'Donation ID was empty', 'chip-for-givewp' ) );

--- a/includes/class-listener.php
+++ b/includes/class-listener.php
@@ -128,7 +128,7 @@ class Chip_Givewp_Listener {
 
 			$content = file_get_contents( 'php://input' );
 
-			if ( openssl_verify( $content, base64_decode(  $_SERVER['HTTP_X_SIGNATURE'] ), $public_key, 'sha256WithRSAEncryption' ) != 1 ) {
+			if ( openssl_verify( $content, base64_decode( $_SERVER['HTTP_X_SIGNATURE'] ), $public_key, 'sha256WithRSAEncryption' ) != 1 ) {
 				$message = __( 'Success callback failed to be processed due to failure in verification.', 'chip-for-givewp' );
 
 				Chip_Givewp_Helper::log( $donation_id, LogType::ERROR, $message );

--- a/includes/class-listener.php
+++ b/includes/class-listener.php
@@ -128,7 +128,7 @@ class Chip_Givewp_Listener {
 
 			$content = file_get_contents( 'php://input' );
 
-			if ( openssl_verify( $content, base64_decode( sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_SIGNATURE'] ) ) ), $public_key, 'sha256WithRSAEncryption' ) != 1 ) {
+			if ( openssl_verify( $content, base64_decode(  $_SERVER['HTTP_X_SIGNATURE'] ), $public_key, 'sha256WithRSAEncryption' ) != 1 ) {
 				$message = __( 'Success callback failed to be processed due to failure in verification.', 'chip-for-givewp' );
 
 				Chip_Givewp_Helper::log( $donation_id, LogType::ERROR, $message );

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -27,13 +27,13 @@ class Chip_Givewp_Purchase {
 		do_action( 'give_before_chip_info_fields', $form_id );
 		?>
 		<fieldset class="no-fields" id="give_chip_payment_info">
-			<?php echo esc_html( stripslashes( wp_kses_post( $instructions ) ) ); ?>
+			<?php echo stripslashes(  $instructions ); ?>
 		</fieldset>
 		<?php
 
 		do_action( 'give_after_chip_info_fields', $form_id );
 
-		echo esc_html( ob_get_clean() );
+		echo wp_kses_post( ob_get_clean() );
 	}
 
 	private function get_instructions( $form_id, $wpautop = false ) {
@@ -160,7 +160,7 @@ class Chip_Givewp_Purchase {
 			'brand_id' => $brand_id,
 			'client' => [ 
 					'email' => $payment_data['user_email'],
-					'full_name' => substr( $payment_data['user_info']['first_name'] . ' ' . $payment_data['user_info']['last_name'], 0, 30 ),
+					'full_name' => trim(substr( $payment_data['user_info']['first_name'] . ' ' . $payment_data['user_info']['last_name'], 0, 30 )),
 				],
 			'purchase' => array(
 				'timezone' => apply_filters( 'gwp_chip_purchase_timezone', $this->get_timezone() ),
@@ -175,11 +175,17 @@ class Chip_Givewp_Purchase {
 		);
 
 		if ( give_is_setting_enabled( $billing_fields ) ) {
-			$params['client']['street_address'] = substr( $payment_data['post_data']['card_address'] ?? 'Address' . ' ' . ( $payment_data['post_data']['card_address_2'] ?? '' ), 0, 128 );
-			$params['client']['country'] = $payment_data['post_data']['billing_country'] ?? 'MY';
-			$params['client']['city'] = $payment_data['post_data']['card_city'] ?? 'Kuala Lumpur';
-			$params['client']['zip_code'] = $payment_data['post_data']['card_zip'] ?? '10000';
-			$params['client']['state'] = substr( $payment_data['post_data']['card_state'], 0, 2 ) ?? 'KL';
+			$params['client']['street_address'] = trim(substr( $payment_data['post_data']['card_address'] ?? '' . ' ' . ( $payment_data['post_data']['card_address_2'] ?? '' ), 0, 128 ));
+			$params['client']['country'] = trim($payment_data['post_data']['billing_country'] ?? '');
+			$params['client']['city'] = trim($payment_data['post_data']['card_city'] ?? '');
+			$params['client']['zip_code'] = trim($payment_data['post_data']['card_zip'] ?? '');
+			$params['client']['state'] = trim(substr( $payment_data['post_data']['card_state'], 0, 2 ) ?? '');
+		}
+
+    foreach ( $params['client'] as $key => $value ) {
+			if ( empty( $value ) ) {
+				unset( $params['client'][ $key ] );
+			}
 		}
 
 		$params = apply_filters( 'gwp_chip_purchase_params', $params, $payment_data, $this );

--- a/includes/class-purchase.php
+++ b/includes/class-purchase.php
@@ -27,7 +27,7 @@ class Chip_Givewp_Purchase {
 		do_action( 'give_before_chip_info_fields', $form_id );
 		?>
 		<fieldset class="no-fields" id="give_chip_payment_info">
-			<?php echo stripslashes(  $instructions ); ?>
+			<?php echo stripslashes( $instructions ); ?>
 		</fieldset>
 		<?php
 
@@ -159,30 +159,30 @@ class Chip_Givewp_Purchase {
 			'due' => time() + ( absint( $due_strict_timing ) * 60 ),
 			'brand_id' => $brand_id,
 			'client' => [ 
-					'email' => $payment_data['user_email'],
-					'full_name' => trim(substr( $payment_data['user_info']['first_name'] . ' ' . $payment_data['user_info']['last_name'], 0, 30 )),
-				],
+				'email' => $payment_data['user_email'],
+				'full_name' => trim( substr( $payment_data['user_info']['first_name'] . ' ' . $payment_data['user_info']['last_name'], 0, 30 ) ),
+			],
 			'purchase' => array(
 				'timezone' => apply_filters( 'gwp_chip_purchase_timezone', $this->get_timezone() ),
 				'currency' => $currency,
 				'due_strict' => give_is_setting_enabled( $due_strict ),
 				'products' => array( [ 
-							'name' => substr( give_payment_gateway_item_title( $payment_data ), 0, 256 ),
-							'price' => round( $payment_data['price'] * 100 ),
-							'quantity' => '1',
-						] ),
+					'name' => substr( give_payment_gateway_item_title( $payment_data ), 0, 256 ),
+					'price' => round( $payment_data['price'] * 100 ),
+					'quantity' => '1',
+				] ),
 			),
 		);
 
 		if ( give_is_setting_enabled( $billing_fields ) ) {
-			$params['client']['street_address'] = trim(substr( $payment_data['post_data']['card_address'] ?? '' . ' ' . ( $payment_data['post_data']['card_address_2'] ?? '' ), 0, 128 ));
-			$params['client']['country'] = trim($payment_data['post_data']['billing_country'] ?? '');
-			$params['client']['city'] = trim($payment_data['post_data']['card_city'] ?? '');
-			$params['client']['zip_code'] = trim($payment_data['post_data']['card_zip'] ?? '');
-			$params['client']['state'] = trim(substr( $payment_data['post_data']['card_state'], 0, 2 ) ?? '');
+			$params['client']['street_address'] = trim( substr( $payment_data['post_data']['card_address'] ?? '' . ' ' . ( $payment_data['post_data']['card_address_2'] ?? '' ), 0, 128 ) );
+			$params['client']['country'] = trim( $payment_data['post_data']['billing_country'] ?? '' );
+			$params['client']['city'] = trim( $payment_data['post_data']['card_city'] ?? '' );
+			$params['client']['zip_code'] = trim( $payment_data['post_data']['card_zip'] ?? '' );
+			$params['client']['state'] = trim( substr( $payment_data['post_data']['card_state'], 0, 2 ) ?? '' );
 		}
 
-    foreach ( $params['client'] as $key => $value ) {
+		foreach ( $params['client'] as $key => $value ) {
 			if ( empty( $value ) ) {
 				unset( $params['client'][ $key ] );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: chipasia, wanzulnet, awisqirani
 Tags: chip
 Requires at least: 4.7
 Tested up to: 6.7
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 7.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -32,8 +32,9 @@ This plugin will enable your GiveWP site to be integrated with CHIP as per docum
 
 == Changelog ==
 
-= 1.2.0 - 2024-12-17 =
-* Added - Support GiveWP 3.0 Visual Donation Form Builder.
+= 1.2.1 - 2025-02-07 =
+* Fixed - Issue with Option-Based Form Editor where payment info show escaped output.
+* Fixed - Remove filtering for webhook to prevent unpredictable failure for openssl_verify.
 
 == Installation ==
 


### PR DESCRIPTION
## What does this change?
This fix issue on legacy form escaping html character.

## Asana / Jira / Trello task link

## How to test

## Images
Before

<img width="737" alt="Screenshot 2025-02-07 at 4 49 21 PM" src="https://github.com/user-attachments/assets/979a2681-e16b-4756-8ad6-26fc5e855332" />

After
<img width="766" alt="Screenshot 2025-02-07 at 4 47 40 PM" src="https://github.com/user-attachments/assets/42642fd9-de02-4b6d-b59a-2af722041116" />

## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
