### PR TITLE
docs: fix CLAUDE.md file paths and README.md installation instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,18 +19,20 @@ Both gateways share the same backend logic (API calls, listener, settings) but h
 ### Core Components
 
 - **`chip-for-givewp.php`** — Main plugin file. Bootstraps all includes and registers the legacy gateway via `give_payment_gateways` filter.
-- **`includes/class-api.php`** — `Chip_Givewp_API`. Wraps CHIP REST API (`https://gate.chip-in.asia/api/v1`). **Important**: `get_instance()` is a **keyed singleton** — instances are cached by `md5($secret_key . '|' . $brand_id)` so the same credentials reuse one instance, but different credentials get separate instances. Added methods: `get_company_uid()`, `cancel_payment()`. `request()` returns `null` on `WP_Error` or non-2xx status codes.
-- **`includes/class-purchase.php`** — `Chip_Givewp_Purchase`. Handles legacy form donation creation and redirect to CHIP checkout.
-- **`includes/block/class-chip-gateway.php`** — `ChipGateway`. Handles block-form donation creation. Also implements `refundDonation()` for block-form refunds.
-- **`includes/class-listener.php`** — `Chip_Givewp_Listener`. Handles CHIP callback/webhook (`handle_callback`) and customer redirect (`handle_redirect`). Verifies webhook signatures via `openssl_verify` using a **company-UID-based cached public key** (`gwp_chip_public_key_{company_uid}`). On verification failure, falls back to fetching payment status via the API. Uses MySQL `GET_LOCK`/`RELEASE_LOCK` (verified with `get_var()`) to prevent duplicate payment processing.
-- **`includes/class-helper.php`** — `Chip_Givewp_Helper`. Static utilities for form settings and logging via `Give\Log\LogFactory`.
+- **`includes/class-chip-givewp-api.php`** — `Chip_Givewp_API`. Wraps CHIP REST API (`https://gate.chip-in.asia/api/v1`). **Important**: `get_instance()` is a **keyed singleton** — instances are cached by `md5($secret_key . '|' . $brand_id)` so the same credentials reuse one instance, but different credentials get separate instances. Added methods: `get_company_uid()`, `cancel_payment()`. `request()` returns `null` on `WP_Error` or non-2xx status codes.
+- **`includes/class-chip-givewp-purchase.php`** — `Chip_Givewp_Purchase`. Handles legacy form donation creation and redirect to CHIP checkout.
+- **`includes/block/class-chipgateway.php`** — `ChipGateway`. Handles block-form donation creation. Also implements `refundDonation()` for block-form refunds.
+- **`includes/class-chip-givewp-listener.php`** — `Chip_Givewp_Listener`. Handles CHIP callback/webhook (`handle_callback`) and customer redirect (`handle_redirect`). Verifies webhook signatures via `openssl_verify` using a **company-UID-based cached public key** (`gwp_chip_public_key_{company_uid}`). On verification failure, falls back to fetching payment status via the API. Uses MySQL `GET_LOCK`/`RELEASE_LOCK` (verified with `get_var()`) to prevent duplicate payment processing.
+- **`includes/class-chip-givewp-helper.php`** — `Chip_Givewp_Helper`. Static utilities for form settings and logging via `Give\Log\LogFactory`.
 - **`includes/admin/`** — Settings UI:
-  - `class-settings.php` — Base settings field definitions (shared by global and per-form settings).
-  - `class-global-settings.php` — Global CHIP settings under GiveWP Settings → Gateways → CHIP.
-  - `class-metabox-settings.php` — Per-form CHIP settings tab in the form editor.
-  - `class-refund-button.php` — Adds a manual refund button to the donation details admin page.
-- **`includes/block/chip-givewp-block.php`** — Registers the `ChipGateway` class with GiveWP's `PaymentGatewayRegister`.
+  - `class-chip-givewp-admin-settings.php` — Base settings field definitions (shared by global and per-form settings).
+  - `class-chip-givewp-admin-global-settings.php` — Global CHIP settings under GiveWP Settings → Gateways → CHIP.
+  - `class-chip-givewp-admin-metabox-settings.php` — Per-form CHIP settings tab in the form editor.
+  - `class-chip-givewp-refund-button.php` — Adds a manual refund button to the donation details admin page.
+- **`includes/block/chip-givewp-block.php`** — `Chip_Givewp_Block`. Bootstraps the block gateway by registering `ChipGateway` with GiveWP's `PaymentGatewayRegister`, and enqueues the form-builder sidebar script.
 - **`includes/block/js/chip-gateway.js`** — Minimal React-based frontend for block forms. Registers `window.givewp.gateways`.
+- **`includes/block/Actions/class-chip-givewp-enqueue-form-builder-scripts.php`** — `Chip_Givewp_Enqueue_Form_Builder_Scripts`. Enqueues a sidebar-link script in the GiveWP Visual Form Builder pointing to per-form CHIP settings.
+- **`includes/block/resources/form-builder/chip-gateway-form-builder.js`** — Form-builder sidebar script that adds a "CHIP Settings" link to the per-form settings tab.
 - **`includes/js/metabox.js`** — Toggles per-form CHIP settings visibility in the legacy form editor.
 - **`includes/js/refund.js`** — AJAX handler for the admin refund button.
 - **`.wp-env.json`** — Local WordPress environment config (GiveWP + plugin-check).
@@ -53,7 +55,7 @@ The `Chip_Givewp_Helper::get_fields()` / `update_fields()` methods abstract this
 ## Development Notes
 
 - **No frontend build step**: Edit PHP/JS files directly.
-- **Composer dev dependencies**: `phpunit/phpunit`, `10up/wp_mock`, `yoast/phpunit-polyfills`.
+- **Composer dev dependencies**: `phpunit/phpunit`, `10up/wp_mock`, `yoast/phpunit-polyfills`, `squizlabs/php_codesniffer`, `dealerdirect/phpcodesniffer-composer-installer`, `wp-coding-standards/wpcs`.
 - **Formatting**: VS Code workspace setting uses `"php.format.codeStyle": "WordPress"`. PHPCS is configured for WordPress standards via `phpcs.xml`.
 - **Minimum PHP**: 7.4 (as of v1.3.0).
 - **Minimum WordPress**: 6.3 (as of v1.3.0).
@@ -83,9 +85,9 @@ phpcs --standard=PHPCompatibilityWP --runtime-set testVersion 8.5 --extensions=p
 
 ## Common Changes
 
-- To modify gateway settings fields: edit `includes/admin/class-settings.php`.
-- To change checkout redirect logic: edit `includes/class-purchase.php::create()` or `includes/block/class-chip-gateway.php::createPayment()`.
-- To adjust webhook verification or payment locking: edit `includes/class-listener.php::handle_processing()`.
+- To modify gateway settings fields: edit `includes/admin/class-chip-givewp-admin-settings.php`.
+- To change checkout redirect logic: edit `includes/class-chip-givewp-purchase.php::create()` or `includes/block/class-chipgateway.php::createPayment()`.
+- To adjust webhook verification or payment locking: edit `includes/class-chip-givewp-listener.php::handle_processing()`.
 - To update version: bump in `chip-for-givewp.php` (header + `GWP_CHIP_MODULE_VERSION`), `readme.txt` (`Stable tag`), and `changelog.txt`. Alternatively, use `./scripts/bump-version.sh X.Y.Z`.
 - To update WordPress.org assets: place images in `.wordpress-org/` (banners, icons, screenshots). Deployed to SVN by `deploy.yml`.
 - To run local WordPress environment: `wp-env` reads `.wp-env.json` (GiveWP + plugin-check pre-installed).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This module adds CHIP payment method option to your GiveWP.
 
 ## Installation
 
-* [Download zip file of Give plugin.](https://github.com/CHIPAsia/chip-for-givewp/archive/refs/heads/main.zip)
+* Download and activate the [GiveWP](https://wordpress.org/plugins/give/) plugin from WordPress.org.
+* [Download the latest CHIP for GiveWP zip.](https://github.com/CHIPAsia/chip-for-givewp/archive/refs/heads/main.zip)
 * Log in to your WordPress admin panel and go: **Plugins** -> **Add New**
-* Select **Upload Plugin**, choose zip file you downloaded in step 1 and press **Install Now**
+* Select **Upload Plugin**, choose the CHIP for GiveWP zip file you downloaded and press **Install Now**
 * Activate plugin
 
 ## Configuration


### PR DESCRIPTION
## What does this change?
This PR corrects documentation inaccuracies in `CLAUDE.md` and `README.md` to align with the actual project structure and improve user onboarding. 

Key changes include:
- **File Path Corrections:** Updated `CLAUDE.md` to use the correct filenames for core components (e.g., prefixing files with `chip-givewp-` and adjusting the block gateway class names) to match the actual codebase.
- **Component Documentation:** Added descriptions for missing form-builder script components (`Chip_Givewp_Enqueue_Form_Builder_Scripts` and its associated JS).
- **Dependency Updates:** Expanded the Composer dev dependencies list to include PHPCS/WPCS packages used for code quality.
- **Onboarding Clarity:** Updated `README.md` to explicitly state that GiveWP is a prerequisite and clarified that the zip file provided is the gateway plugin, not the core GiveWP plugin.

## How to test
1.  **Verify Paths:** Cross-reference the updated file paths in `CLAUDE.md` against the repository's file system (e.g., check that `includes/class-chip-givewp-api.php` exists while `includes/class-api.php` does not).
2.  **Verify README:** Read the "Installation" section of the `README.md` to ensure the flow is logical for a new user.
3.  **Verify Links:** Ensure the GitHub download link and WordPress.org link in `README.md` are functional.

## Potential Risks & Review Items
- **Documentation Drift:** While this fixes existing inaccuracies, care should be taken in future PRs to update `CLAUDE.md` if files are renamed again.
- **Zero Runtime Risk:** This PR only modifies Markdown files; there is no impact on plugin functionality.

## Is this PR safe for automatic approval?
Yes. This is a documentation-only update that synchronizes developer/user guides with the existing codebase.

## Images
N/A

## Related Tasks / PRs
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Checklist
- [ ] Unit tests provided? (N/A)
- [ ] All tests passing?
- [x] Tested in staging?
- [ ] Task link provided?
